### PR TITLE
Update shodan_eye.py

### DIFF
--- a/shodan_eye.py
+++ b/shodan_eye.py
@@ -128,7 +128,7 @@ def showdam():
         file.close()
 
     api = shodan.Shodan(shodan_api_key)
-    time.sleep(0.4)
+    time.sleep(1)
 
     limit = 888  # Just a number
     counter = 1


### PR DESCRIPTION
Prevent "only one request per second" throttle exception (somehow Shodan considers the reference on the API object as "API call", duh).