### PR TITLE
docs: fix script filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ pip3 install -r requirements.txt
 
 # How to use Shodan Eye
 ```bash
-python3 shodan_eye.py
+python3 shodan-eye.py
 ```
 
 (You will be asked for a Shodan API key)


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct the README command from `shodan_eye.py` to `shodan-eye.py`.

Fixes #18

## Test plan
- static validation: `shodan_eye.py` appeared 1 time(s) in `README.md` before replacement.
- static validation: `shodan_eye.py` absent and `shodan-eye.py` present in `README.md` after patch.
- Not run: runtime test suite, because this is a documentation-only fix.
